### PR TITLE
Db rule update

### DIFF
--- a/configure/module/RULES_MODULE
+++ b/configure/module/RULES_MODULE
@@ -2,8 +2,9 @@
 .PHONY: db hdrs epics epics-clean
 
 db: conf
-	install -m 644 $(TOP)/template/pointGreyPG1-ess.substitutions  $(E3_MODULE_SRC_PATH)/pointGreyApp/Db/
-	install -m 644 $(TOP)/template/pointGreyPG2-ess.substitutions  $(E3_MODULE_SRC_PATH)/pointGreyApp/Db/
+	#install -m 644 $(TOP)/template/pointGreyPG1-ess.substitutions  $(E3_MODULE_SRC_PATH)/pointGreyApp/Db/
+	#install -m 644 $(TOP)/template/pointGreyPG2-ess.substitutions  $(E3_MODULE_SRC_PATH)/pointGreyApp/Db/
+	install -m 644 $(TOP)/template/*-ess.substitutions  $(E3_MODULE_SRC_PATH)/pointGreyApp/Db/
 	$(QUIET) $(E3_MODULE_MAKE_CMDS) db
 
 hdrs:

--- a/template/pointGrey-ess.substitutions
+++ b/template/pointGrey-ess.substitutions
@@ -1,0 +1,45 @@
+# Note.  These substutitions are mostly generic.
+# However the PINI, PINI_VALB, and PINI_ABS fields should be changed to only be
+# YES for the features the camera actually supports in device or absolute
+# mode, otherwise error messages will appear on startup.
+# One would normally set either PINI or PINI_ABS to YES (but not both) because
+# if they are both YES the results are unpredictable, depending
+# on which happens last. 
+# PINI_VALB should only be set to YES for the WhiteBalance property in color cameras 
+# that support WhiteBalance.
+
+file "pointGreyProperty.template" 
+{ 
+pattern
+{      PROPERTY,     N, PINI, PINI_VALB, PINI_ABS, PHAS }
+{    Brightness,     0,   NO,        NO,      YES,    1 }
+{  AutoExposure,     1,   NO,        NO,      YES,    1 }
+{     Sharpness,     2,   NO,        NO,      YES,    1 }
+{  WhiteBalance,     3,   NO,       YES,       NO,    1 }
+{           Hue,     4,   NO,        NO,      YES,    1 }
+{    Saturation,     5,   NO,        NO,      YES,    1 }
+{         Gamma,     6,   NO,        NO,      YES,    1 }
+{          Iris,     7,  YES,        NO,       NO,    1 }
+{         Focus,     8,  YES,        NO,       NO,    1 }
+{          Zoom,     9,  YES,        NO,       NO,    1 }
+{           Pan,    10,  YES,        NO,       NO,    1 }
+{          Tilt,    11,  YES,        NO,       NO,    1 }
+#  Don't set PINI on Shutter property, it is set from AcquireTime record
+{       Shutter,    12,   NO,        NO,       NO,    1 }
+# Don't set PINI on Gain property, it is set from Gain record
+{          Gain,    13,   NO,        NO,       NO,    1 }
+{   TriggerMode,    14,   NO,        NO,       NO,    1 }
+{  TriggerDelay,    15,   NO,        NO,      YES,    1 }
+{     FrameRate,    16,   NO,        NO,      YES,    1 }
+{   Temperature,    17,   NO,        NO,       NO,    1 }
+}
+
+file "pointGreyGigEProperty.template" 
+{ 
+pattern
+{          PROPERTY,     N, PINI }
+{         Heartbeat,     0,  NO  }
+{  HeartbeatTimeout,     1,  NO  }
+{        PacketSize,     2, YES  }
+{       PacketDelay,     3, YES  }
+}


### PR DESCRIPTION
Updates ESS database rule to include any database file from the template directory that ends with -ess. 

Replace the custom PG1 and PG2 databases with a generic database where the P, R and PORT macros must be defined in the dbLoadRecords command in the IOC startup script.